### PR TITLE
handleScroll on componentDidUpdate

### DIFF
--- a/dist/LazyLoad.js
+++ b/dist/LazyLoad.js
@@ -30,6 +30,9 @@ var React = require('react/addons'),
             window.addEventListener('resize', this.handleScroll);
             this.handleScroll();
         },
+        componentDidUpdate: function() {
+            if(!this.state.visible) this.handleScroll()
+        },
         componentWillUnmount: function() {
             this.handleVisible();
         },

--- a/src/LazyLoad.js
+++ b/src/LazyLoad.js
@@ -30,6 +30,9 @@ var React = require('react/addons'),
             window.addEventListener('resize', this.handleScroll);
             this.handleScroll();
         },
+        componentDidUpdate: function() {
+            if(!this.state.visible) this.handleScroll();
+        },
         componentWillUnmount: function() {
             this.handleVisible();
         },


### PR DESCRIPTION
I'm lazy-loading search results, with a "preview" feature on a search page that temporarily re-orders the results to let users "peek" at one of the top results without scrolling down.

Checking `handleScroll` on `componentDidUpdate` covers a component moving into view through a change to app state instead of a scrollEvent. (Previously the empty `<LazyLoad>` would sit in the viewport until a scroll event caused it to realize it should be `visible`.)