### PR TITLE
Add React requirement explicitly

### DIFF
--- a/dist/LazyLoad.js
+++ b/dist/LazyLoad.js
@@ -1,4 +1,5 @@
-var ClassNames = require('classnames'),
+var React = require('react'),
+    ClassNames = require('classnames'),
 
     LazyLoad = React.createClass({
         displayName: 'LazyLoad',

--- a/src/LazyLoad.js
+++ b/src/LazyLoad.js
@@ -1,4 +1,5 @@
-var ClassNames = require('classnames'),
+var React = require('react'),
+    ClassNames = require('classnames'),
 
     LazyLoad = React.createClass({
         displayName: 'LazyLoad',


### PR DESCRIPTION
This PR simply adds the React package before referencing it. Otherwise, it is assumed React is globally defined.

cc: @loktar00