### PR TITLE
Only publish needed files to npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "1.0.2",
   "description": "Simple lazy loading component built with react",
   "main": "dist/LazyLoad.js",
+  "files": [
+    "dist/LazyLoad.js"
+  ],
   "scripts": {
     "build": "node_modules/.bin/jsx src/ dist/",
     "test": "echo \"Error: no test specified\" && exit 1"


### PR DESCRIPTION
Currently when installing from npm the module folder contains examples and the JSX source too even though only `dist/LazyLoad.js` is needed to consume the module.

This PR adds `dist/LazyLoad.js` to the `files` array in the package.json so only the consumable module and the standard files (package.json, README.md, LICENSE) will be published.