### PR TITLE
Migrate to react 0.14

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "classnames": "^2.1.2"
   },
   "peerDependencies": {
-    "react": "^0.13.x||^0.14.0-rc"
+    "react": "^0.13.x||^0.14.0"
   },
   "devDependencies": {
     "react-tools": "^0.13.0"

--- a/src/LazyLoad.js
+++ b/src/LazyLoad.js
@@ -12,7 +12,7 @@ var React = require('react'),
             };
         },
         handleScroll: function() {
-            var bounds = this.getDOMNode().getBoundingClientRect(),
+            var bounds = React.findDOMNode(this).getBoundingClientRect(),
                 scrollTop = window.pageYOffset,
                 top = bounds.top + scrollTop,
                 height = bounds.bottom - bounds.top;


### PR DESCRIPTION
Only one change: `getDOMNode` is deprecated in 0.14, and is replaced with `findDOMNode(this)`.

https://facebook.github.io/react/blog/2015/07/03/react-v0.14-beta-1.html#dom-node-refs