### PR TITLE
Add React-dom

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
     "classnames": "^2.1.5"
   },
   "peerDependencies": {
-    "react": "^0.13.x||^0.14.0"
+    "react": "^0.14.0",
+    "react-dom": "^0.14.0"
   },
   "devDependencies": {
     "babel-core": "^5.8.25",

--- a/src/LazyLoad.jsx
+++ b/src/LazyLoad.jsx
@@ -1,4 +1,5 @@
-import React, { Component, findDOMNode, PropTypes } from 'react';
+import React, { Component, PropTypes } from 'react';
+import { findDOMNode } from 'react-dom';
 import classNames from 'classnames';
 
 export default class LazyLoad extends Component {


### PR DESCRIPTION
In react 0.14 we have two separate packages — React and React-DOM. `findDOMNode` now part of React-DOM.