### PR TITLE
Minimize calls to addEventListener and throttle handlers

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "classnames": "^2.2.0"
   },
   "devDependencies": {
+    "babel-cli": "^6.3.15",
     "babel-core": "^6.2.1",
     "babel-eslint": "^4.1.5",
     "babel-loader": "^6.2.0",
@@ -49,6 +50,7 @@
     "eslint-plugin-react": "^3.7.1",
     "react": "^0.14.0",
     "react-dom": "^0.14.0",
+    "rimraf": "^2.4.4",
     "style-loader": "^0.13.0",
     "webpack": "^1.12.2",
     "webpack-dev-server": "^1.12.1"

--- a/src/LazyLoad.jsx
+++ b/src/LazyLoad.jsx
@@ -1,31 +1,31 @@
 import React, { Component, PropTypes } from 'react';
 import { findDOMNode } from 'react-dom';
 import classNames from 'classnames';
+import ViewportDimensions from './ViewportDimensions';
+
+const viewportDimensions = new ViewportDimensions();
 
 export default class LazyLoad extends Component {
-  constructor(props) {
-    super(props);
-    this.onWindowScroll = this.onWindowScroll.bind(this);
-  }
   state = {
     visible: false,
   }
   componentDidMount() {
-    window.addEventListener('scroll', this.onWindowScroll);
-    window.addEventListener('resize', this.onWindowScroll);
+    this.removeViewportListener = viewportDimensions.addListener(this.onWindowScroll.bind(this));
     this.onWindowScroll();
   }
   componentDidUpdate() {
     if (!this.state.visible) this.onWindowScroll();
   }
   componentWillUnmount() {
-    this.onVisible();
-  }
-  onVisible() {
-    window.removeEventListener('scroll', this.onWindowScroll);
-    window.removeEventListener('resize', this.onWindowScroll);
+    this.removeViewportListener();
   }
   onWindowScroll() {
+    if (this.isInViewport()) {
+      this.setState({ visible: true });
+      this.removeViewportListener();
+    }
+  }
+  isInViewport() {
     const { threshold } = this.props;
 
     const bounds = findDOMNode(this).getBoundingClientRect();
@@ -33,11 +33,8 @@ export default class LazyLoad extends Component {
     const top = bounds.top + scrollTop;
     const height = bounds.bottom - bounds.top;
 
-    if (top === 0 || (top <= (scrollTop + window.innerHeight + threshold)
-                      && (top + height) > (scrollTop - threshold))) {
-      this.setState({ visible: true });
-      this.onVisible();
-    }
+    return (top === 0 || (top <= (scrollTop + window.innerHeight + threshold)
+                      && (top + height) > (scrollTop - threshold)));
   }
   render() {
     const elStyles = {

--- a/src/ViewportDimensions.js
+++ b/src/ViewportDimensions.js
@@ -1,0 +1,50 @@
+function throttle(fn, threshold = 250) {
+  let last;
+  let deferTimer;
+  return (...args) => {
+    const context = this;
+    const now = +new Date;
+    if (last && now < last + threshold) {
+      // hold on to it
+      clearTimeout(deferTimer);
+      deferTimer = setTimeout(() => {
+        last = now;
+        fn.apply(context, args);
+      }, threshold);
+    } else {
+      last = now;
+      fn.apply(context, args);
+    }
+  };
+}
+
+function attempt(callback) {
+  try {
+    return callback();
+  } catch (error) {
+    return error;
+  }
+}
+
+export default class ViewportDimensions {
+  constructor(threshold = 250) {
+    this.callbacks = [];
+    this.onWindowScroll = throttle(() => this.onWindowScroll(), threshold);
+    window.addEventListener('scroll', this.onWindowScroll);
+    window.addEventListener('resize', this.onWindowScroll);
+  }
+  destroy() {
+    window.removeEventListener('scroll', this.onWindowScroll);
+    window.removeEventListener('resize', this.onWindowScroll);
+  }
+  addListener(callback) {
+    this.callbacks = this.callbacks.concat(callback);
+    return () => this.removeListener(callback);
+  }
+  removeListener(callback) {
+    this.callbacks = this.callbacks.filter(c => c !== callback);
+  }
+  onWindowScroll() {
+    this.callbacks.forEach(callback => attempt(callback));
+  }
+}


### PR DESCRIPTION
I think that these changes should provide a performance enhancement.  I wasn't able to fully test it locally because I couldn't figure out how to install react-lazy-load from my fork and have babel successfully build react-lazy-load's source.