### PR TITLE
Fix broken build by adding a missing semicolon after a class property

### DIFF
--- a/src/LazyLoad.jsx
+++ b/src/LazyLoad.jsx
@@ -9,7 +9,7 @@ export default class LazyLoad extends Component {
   }
   state = {
     visible: false,
-  }
+  };
   componentDidMount() {
     window.addEventListener('scroll', this.onWindowScroll);
     window.addEventListener('resize', this.onWindowScroll);


### PR DESCRIPTION
Fix build issue :

```js
SyntaxError: src/LazyLoad.jsx: A semicolon is required after a class property (13:2)
  11 |     visible: false,
  12 |   }
> 13 |   componentDidMount() {
```