### PR TITLE
Add eventNode prop to support listening to DOM elements other than window

### DIFF
--- a/src/LazyLoad.jsx
+++ b/src/LazyLoad.jsx
@@ -11,8 +11,9 @@ export default class LazyLoad extends Component {
     visible: false,
   };
   componentDidMount() {
-    window.addEventListener('scroll', this.onWindowScroll);
-    window.addEventListener('resize', this.onWindowScroll);
+    const eventNode = this.getEventNode();
+    eventNode.addEventListener('scroll', this.onWindowScroll);
+    eventNode.addEventListener('resize', this.onWindowScroll);
     this.onWindowScroll();
   }
   componentDidUpdate() {
@@ -30,22 +31,41 @@ export default class LazyLoad extends Component {
     this.onVisible();
   }
   onVisible() {
-    window.removeEventListener('scroll', this.onWindowScroll);
-    window.removeEventListener('resize', this.onWindowScroll);
+    const eventNode = this.getEventNode();
+    eventNode.removeEventListener('scroll', this.onWindowScroll);
+    eventNode.removeEventListener('resize', this.onWindowScroll);
   }
   onWindowScroll() {
     const { threshold } = this.props;
+    const eventNode = this.getEventNode();
+
+    let scrollTop = 0;
+    let innerHeight = 0;
+
+    if (eventNode === window) {
+      scrollTop = window.pageYOffset;
+      innerHeight = window.innerHeight;
+    } else {
+      scrollTop = eventNode.scrollTop;
+      innerHeight = eventNode.clientHeight;
+    }
 
     const bounds = findDOMNode(this).getBoundingClientRect();
-    const scrollTop = window.pageYOffset;
     const top = bounds.top + scrollTop;
     const height = bounds.bottom - bounds.top;
 
-    if (top === 0 || (top <= (scrollTop + window.innerHeight + threshold)
+    if (top === 0 || (top <= (scrollTop + innerHeight + threshold)
                       && (top + height) > (scrollTop - threshold))) {
       this.setState({ visible: true });
       this.onVisible();
     }
+  }
+  getEventNode() {
+    if (this.props.eventNode) {
+      return this.props.eventNode;
+    }
+
+    return window;
   }
   render() {
     const elStyles = {
@@ -66,6 +86,7 @@ export default class LazyLoad extends Component {
 
 LazyLoad.propTypes = {
   children: PropTypes.node.isRequired,
+  eventNode: PropTypes.node,
   height: PropTypes.oneOfType([
     PropTypes.string,
     PropTypes.number,

--- a/src/LazyLoad.jsx
+++ b/src/LazyLoad.jsx
@@ -86,7 +86,7 @@ export default class LazyLoad extends Component {
 
 LazyLoad.propTypes = {
   children: PropTypes.node.isRequired,
-  eventNode: PropTypes.node,
+  eventNode: PropTypes.any,
   height: PropTypes.oneOfType([
     PropTypes.string,
     PropTypes.number,


### PR DESCRIPTION
Hi there. I love this component. I was happily building with it when I ran into an issue: I decided to nest my `LazyLoad` components in an element that had `overflow-y` set to `scroll` and the lazy loading stopped working.

I delved into source and realized that this is because the event listener listens to `window`, and my element didn't scroll the entire window. In this PR, I add a prop called `eventNode` that allows the user to pass in a ref to a node they're scrolling, and have the `LazyLoad` component listen to that node instead.

Contrived example:

```jsx
<div ref="scrollContainer">
  <LazyLoad height={200} eventNode={this.refs.scrollContainer}>
    <div>No mom, you do the dishes</div>
  </LazyLoad>
</div>
```

In practice, you'd actually have to wait for the initial render, set `scrollContainer` to `state`, and only render the `LazyLoad` component once `this.state.scrollContainer` exists.

Seems to work well, let me know if this fits in the scope of the project or if you have any feedback. Thanks!