### PR TITLE
Bug fix: inViewport always evalutes true when overflow-x hidden on html tag

### DIFF
--- a/src/utils/parentScroll.js
+++ b/src/utils/parentScroll.js
@@ -18,7 +18,7 @@ const scrollParent = (element) => {
       return window;
     }
 
-    if (parent !== document.body && /(scroll|auto)/.test(overflow(parent))) {
+    if (parent !== document.body && parent!== document.documentElement && /(scroll|auto)/.test(overflow(parent))) {
       return parent;
     }
 


### PR DESCRIPTION
Hi there,

I created this PR to fix a bug when using the css propery overflow-x: hidden on the html tag. The inViewport function is evaluating always true even when the images aren't in the viewport. The parentScroll function is not taking into account the html tag (just the body tag).

To reproduce just add ```style="overflow-x: hidden;"``` to the html tag on the example file ```examples/basic/initializers/server/template.ejs``` then run the example.