### PR TITLE
Use throttle when debounce is disabled

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
   "dependencies": {
     "eventlistener": "0.0.1",
     "lodash.debounce": "^4.0.0",
-    "lodash.throttle": "^4.0.1"
+    "lodash.throttle": "^4.0.0"
   },
   "peerDependencies": {
     "react": "^0.14.0",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,8 @@
   },
   "dependencies": {
     "eventlistener": "0.0.1",
-    "lodash.debounce": "^4.0.0"
+    "lodash.debounce": "^4.0.0",
+    "lodash.throttle": "^4.0.1"
   },
   "peerDependencies": {
     "react": "^0.14.0",

--- a/src/LazyLoad.jsx
+++ b/src/LazyLoad.jsx
@@ -15,10 +15,12 @@ class LazyLoad extends Component {
 
     this.lazyLoadHandler = this.lazyLoadHandler.bind(this);
 
-    if (props.debounce) {
-      this.lazyLoadHandler = debounce(this.lazyLoadHandler, props.throttle);
-    } else {
-      this.lazyLoadHandler = throttle(this.lazyLoadHandler, props.throttle);
+    if (props.throttle > 0) {
+      if (props.debounce) {
+        this.lazyLoadHandler = debounce(this.lazyLoadHandler, props.throttle);
+      } else {
+        this.lazyLoadHandler = throttle(this.lazyLoadHandler, props.throttle);
+      }
     }
 
     this.state = { visible: false };

--- a/src/LazyLoad.jsx
+++ b/src/LazyLoad.jsx
@@ -4,6 +4,7 @@ const { Children, Component, PropTypes } = React;
 
 const { add, remove } = require('eventlistener');
 const debounce = require('lodash.debounce');
+const throttle = require('lodash.throttle');
 
 const parentScroll = require('./utils/parentScroll');
 const inViewport = require('./utils/inViewport');
@@ -16,6 +17,8 @@ class LazyLoad extends Component {
 
     if (props.debounce) {
       this.lazyLoadHandler = debounce(this.lazyLoadHandler, props.throttle);
+    } else {
+      this.lazyLoadHandler = throttle(this.lazyLoadHandler, props.throttle);
     }
 
     this.state = { visible: false };


### PR DESCRIPTION
No throttling was applied when debounce was set to false. I assume this wasn't the indented behavior as the README claims that traditional throttling is used when debounce is disabled.

Maybe we should also check if the throttle time is greater than zero before applying debounce/throttle? This would save the extra function call if you really want to disable throttling.