### PR TITLE
Add SSR support

### DIFF
--- a/src/LazyLoad.jsx
+++ b/src/LazyLoad.jsx
@@ -35,6 +35,7 @@ class LazyLoad extends Component {
       this.lazyLoadHandler.flush();
     }
 
+    add(window, 'load', this.lazyLoadHandler);
     add(window, 'resize', this.lazyLoadHandler);
     add(eventNode, 'scroll', this.lazyLoadHandler);
   }
@@ -99,6 +100,7 @@ class LazyLoad extends Component {
   detachListeners() {
     const eventNode = this.getEventNode();
 
+    remove(window, 'load', this.lazyLoadHandler);
     remove(window, 'resize', this.lazyLoadHandler);
     remove(eventNode, 'scroll', this.lazyLoadHandler);
   }


### PR DESCRIPTION
When using SSR, `.componentDidMount()` is called on the server. It results in images, which should be visible, not being shown. To fix this I've added the window's load event listener.