### PR TITLE
add shallow equal to shouldComponentUpdate

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "jest-cli": "^12.0.2",
     "lodash.debounce": "^4.0.0",
     "lodash.throttle": "^4.0.0",
+    "react-addons-shallow-compare": "^15.3.1",
     "react-addons-test-utils": "^0.14.8"
   },
   "peerDependencies": {

--- a/src/LazyLoad.jsx
+++ b/src/LazyLoad.jsx
@@ -3,6 +3,7 @@ import { findDOMNode } from 'react-dom';
 import { add, remove } from 'eventlistener';
 import debounce from 'lodash.debounce';
 import throttle from 'lodash.throttle';
+import shallowCompare from 'react-addons-shallow-compare';
 import parentScroll from './utils/parentScroll';
 import inViewport from './utils/inViewport';
 
@@ -42,8 +43,8 @@ export default class LazyLoad extends Component {
     }
   }
 
-  shouldComponentUpdate(_nextProps, nextState) {
-    return nextState.visible;
+  shouldComponentUpdate(nextProps, nextState) {
+    return shallowCompare(this, nextProps, nextState);
   }
 
   componentWillUnmount() {


### PR DESCRIPTION
I ran into this problem while setting the height property in a parent components `componentDidMount` block: updating the height property was not reflected in the LazyLoad component. This PR, updates the component when props or state change.
