### PR TITLE
add support for a placeholder

### DIFF
--- a/src/LazyLoad.jsx
+++ b/src/LazyLoad.jsx
@@ -101,7 +101,7 @@ export default class LazyLoad extends Component {
   }
 
   render() {
-    const { children, className, height, width } = this.props;
+    const { children, className, height, width, placeholder } = this.props;
     const { visible } = this.state;
 
     const elStyles = { height, width };
@@ -113,7 +113,7 @@ export default class LazyLoad extends Component {
 
     return (
       <div className={elClasses} style={elStyles}>
-        {visible && Children.only(children)}
+        {visible ? Children.only(children) : placeholder}
       </div>
     );
   }
@@ -134,6 +134,7 @@ LazyLoad.propTypes = {
   offsetRight: PropTypes.number,
   offsetTop: PropTypes.number,
   offsetVertical: PropTypes.number,
+  placeholder: PropTypes.node,
   threshold: PropTypes.number,
   throttle: PropTypes.number,
   width: PropTypes.oneOfType([


### PR DESCRIPTION
This extends the API with a `placeholder` prop: the placeholder (anything that can be rendered) will appear until the LazyLoaded element scrolls into view. This makes it easy to use a loading component.

```
<LazyLoad placholder={<div>LOADING</div>}>
  <img src="http://example.com/my-image.jpg" />
</LazyLoad>
```
