### PR TITLE
Call onContentVisible in setState callback

### DIFF
--- a/src/LazyLoad.jsx
+++ b/src/LazyLoad.jsx
@@ -84,12 +84,12 @@ export default class LazyLoad extends Component {
     if (inViewport(node, eventNode, offset)) {
       const { onContentVisible } = this.props;
 
-      this.setState({ visible: true });
+      this.setState({ visible: true }, () => {
+        if (onContentVisible) {
+          onContentVisible();
+        }
+      });
       this.detachListeners();
-
-      if (onContentVisible) {
-        onContentVisible();
-      }
     }
   }
 


### PR DESCRIPTION
I’m not sure if this has been considered but the name suggests that the content is available when `onContentVisible` is called. This ensures the element has been added to the DOM before calling the function because `setState` runs asynchronously.