### PR TITLE
Add option to toggle visibility on/off

### DIFF
--- a/src/LazyLoad.jsx
+++ b/src/LazyLoad.jsx
@@ -37,7 +37,7 @@ export default class LazyLoad extends Component {
   }
 
   componentWillReceiveProps() {
-    if (!this.state.visible) {
+    if (!this.state.visible || this.props.toggleVisibility) {
       this.lazyLoadHandler();
     }
   }
@@ -90,6 +90,10 @@ export default class LazyLoad extends Component {
         }
       });
       this.detachListeners();
+    } else if (this.props.toggleVisibility) {
+      this.setState({
+        visible: false,
+      });
     }
   }
 
@@ -136,6 +140,7 @@ LazyLoad.propTypes = {
   offsetVertical: PropTypes.number,
   threshold: PropTypes.number,
   throttle: PropTypes.number,
+  toggleVisibility: PropTypes.bool,
   width: PropTypes.oneOfType([
     PropTypes.string,
     PropTypes.number,
@@ -153,4 +158,5 @@ LazyLoad.defaultProps = {
   offsetTop: 0,
   offsetVertical: 0,
   throttle: 250,
+  toggleVisibility: false,
 };


### PR DESCRIPTION
Adds the option to toggle visibility of elements on / off

This allows me to effectively keep track of what elements are actually visible now (and not include what have previously been visible) - allows for nice optimisations with `will-change` CSS property for elements that are close to coming in viewport