### PR TITLE
Fix Issue #83: Issue with event firing on unmounted component.

### DIFF
--- a/src/LazyLoad.jsx
+++ b/src/LazyLoad.jsx
@@ -24,6 +24,7 @@ export default class LazyLoad extends Component {
   }
 
   componentDidMount() {
+    this._mounted = true;
     const eventNode = this.getEventNode();
 
     this.lazyLoadHandler();
@@ -47,6 +48,7 @@ export default class LazyLoad extends Component {
   }
 
   componentWillUnmount() {
+    this._mounted = false;
     if (this.lazyLoadHandler.cancel) {
       this.lazyLoadHandler.cancel();
     }
@@ -77,6 +79,9 @@ export default class LazyLoad extends Component {
   }
 
   lazyLoadHandler() {
+    if (!this._mounted) {
+      return;
+    }
     const offset = this.getOffset();
     const node = findDOMNode(this);
     const eventNode = this.getEventNode();


### PR DESCRIPTION
This is a pretty terrible hack which resolves the problem I am seeing in issue #83. React considers this solution to be an anti-pattern. However, I don't see how to change the cleanup code to avoid the problem.