### PR TITLE
Source lodash functions properly

### DIFF
--- a/src/LazyLoad.jsx
+++ b/src/LazyLoad.jsx
@@ -2,8 +2,8 @@ import React, { Children, Component } from 'react';
 import PropTypes from 'prop-types';
 import { findDOMNode } from 'react-dom';
 import { add, remove } from 'eventlistener';
-import debounce from 'lodash.debounce';
-import throttle from 'lodash.throttle';
+import debounce from 'lodash/debounce';
+import throttle from 'lodash/throttle';
 import parentScroll from './utils/parentScroll';
 import inViewport from './utils/inViewport';
 


### PR DESCRIPTION
The dot syntax was including all of lodash, the slash syntax is the suggested usage on lodash's npm page.