### PR TITLE
added lazy load for whole container out of viewport

### DIFF
--- a/src/LazyLoad.jsx
+++ b/src/LazyLoad.jsx
@@ -36,6 +36,8 @@ export default class LazyLoad extends Component {
 
     add(window, 'resize', this.lazyLoadHandler);
     add(eventNode, 'scroll', this.lazyLoadHandler);
+
+    if (eventNode !== window) add(window, 'scroll', this.lazyLoadHandler);
   }
 
   componentWillReceiveProps() {
@@ -104,6 +106,8 @@ export default class LazyLoad extends Component {
 
     remove(window, 'resize', this.lazyLoadHandler);
     remove(eventNode, 'scroll', this.lazyLoadHandler);
+
+    if (eventNode !== window) remove(window, 'scroll', this.lazyLoadHandler);
   }
 
   render() {

--- a/src/utils/inViewport.js
+++ b/src/utils/inViewport.js
@@ -19,6 +19,8 @@ export default function inViewport(element, container, customOffset) {
     bottom = top + window.innerHeight;
     right = left + window.innerWidth;
   } else {
+    if (!inViewport(container, window, customOffset)) return false;
+
     const containerPosition = getElementPosition(container);
 
     top = containerPosition.top;


### PR DESCRIPTION
Imagine a carousel of images. If each item is Lazy loaded, the first items will be loaded and the ones at the right will wait until the user scrolls horizontally.

If the carousel is out of the initial viewport, the first images will also be loaded because they are "visible" on the container, but they are out of the screen. So, in this pull request I'm waiting the user scrolls to see the carousel in order to load the first images and then continue normally.