### PR TITLE
Replace lodash per-method packages with scoped imports

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,8 +54,7 @@
   },
   "dependencies": {
     "eventlistener": "0.0.1",
-    "lodash.debounce": "^4.0.0",
-    "lodash.throttle": "^4.0.0",
+    "lodash": "^4.0.0",
     "prop-types": "^15.5.8"
   },
   "peerDependencies": {

--- a/src/LazyLoad.jsx
+++ b/src/LazyLoad.jsx
@@ -2,8 +2,8 @@ import React, { Children, Component } from 'react';
 import PropTypes from 'prop-types';
 import { findDOMNode } from 'react-dom';
 import { add, remove } from 'eventlistener';
-import debounce from 'lodash.debounce';
-import throttle from 'lodash.throttle';
+import debounce from 'lodash/debounce';
+import throttle from 'lodash/throttle';
 import parentScroll from './utils/parentScroll';
 import inViewport from './utils/inViewport';
 


### PR DESCRIPTION
The per-method packages are zero-dependency modules, so they often
include a bunch of extra code compared to importing from lodash/foo. We
can save some bundle size by using these partial includes instead.

Additionally, if I recall correctly, the per-method packages are all
deprecated and no longer updated, so this is the way to go for lodash
moving forward.