### PR TITLE
Allow using "getPropertyValue" when "getComputedStyle" is null

### DIFF
--- a/src/utils/parentScroll.js
+++ b/src/utils/parentScroll.js
@@ -1,7 +1,9 @@
-const style = (element, prop) =>
-  typeof getComputedStyle !== 'undefined'
-    ? getComputedStyle(element, null).getPropertyValue(prop)
-    : element.style[prop];
+const style = (element, prop) => {
+  const computedValue = getComputedStyle !== 'undefined' && getComputedStyle(element, null) ?
+    getComputedStyle(element, null).getPropertyValue(prop) : null;
+
+  return computedValue || element.style[prop];
+}
 
 const overflow = (element) =>
   style(element, 'overflow') + style(element, 'overflow-y') + style(element, 'overflow-x');


### PR DESCRIPTION
Due to a really weird issue on FF, calling **getComputedStyle** inside an iframe that was initialized with ```display: none``` will alway return **null**.

This simply check avoids this to break when we check for the ```overflow``` property of the element.

More info here --> https://bugzilla.mozilla.org/show_bug.cgi?id=548397