### PR TITLE
Allow users to pass a custom "scrollElement"

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,3 +113,8 @@ The `width` option allows you to set the element's width even when it has no con
 Type `Function`
 
 A callback function to execute when the content appears on the screen.
+
+#### scrollElement
+Type `Element`
+
+An Element which we used to listen scroll events on it. By default the library will try to find the closest parent element which has any overflow property (```overflow```, ```overflow-x```, ```overflow```) set to **scroll|auto**

--- a/src/LazyLoad.jsx
+++ b/src/LazyLoad.jsx
@@ -58,7 +58,9 @@ export default class LazyLoad extends Component {
   }
 
   getEventNode() {
-    return parentScroll(findDOMNode(this));
+    const {scrollElement} = this.props;
+
+    return scrollElement || parentScroll(findDOMNode(this));
   }
 
   getOffset() {
@@ -147,6 +149,7 @@ LazyLoad.propTypes = {
     PropTypes.number,
   ]),
   onContentVisible: PropTypes.func,
+  scrollElement: PropTypes.element,
 };
 
 LazyLoad.defaultProps = {


### PR DESCRIPTION
This PR introduces a new property **scrollElement**, which will let LazyLoad know about which element the user wants to listen for scroll events.

Some benefits of this: 

* Avoid having to find the closest ```parentElement``` which has a valid overflow property, which is an expensive operation.

* Sometimes the element that the user wants to listen events doesn't have an active scrolling.
