### PR TITLE
Add "wrapperClassName" prop

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "react-lazy-load-zz",
-  "version": "3.0.14",
+  "name": "react-lazy-load",
+  "version": "3.0.12",
   "description": "Simple lazy loading component built with react",
   "main": "./lib/LazyLoad.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-lazy-load-zz",
-  "version": "3.0.12",
+  "version": "3.0.13",
   "description": "Simple lazy loading component built with react",
   "main": "./lib/LazyLoad.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-lazy-load-zz",
-  "version": "3.0.13",
+  "version": "3.0.14",
   "description": "Simple lazy loading component built with react",
   "main": "./lib/LazyLoad.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "react-lazy-load",
+  "name": "react-lazy-load-zz",
   "version": "3.0.12",
   "description": "Simple lazy loading component built with react",
   "main": "./lib/LazyLoad.js",

--- a/src/LazyLoad.jsx
+++ b/src/LazyLoad.jsx
@@ -58,7 +58,9 @@ export default class LazyLoad extends Component {
   }
 
   getEventNode() {
-    return parentScroll(findDOMNode(this));
+    const {wrapperClassName} = this.props;
+
+    return parentScroll(findDOMNode(this), wrapperClassName);
   }
 
   getOffset() {
@@ -147,6 +149,7 @@ LazyLoad.propTypes = {
     PropTypes.number,
   ]),
   onContentVisible: PropTypes.func,
+  wrapperClassName: PropTypes.string,
 };
 
 LazyLoad.defaultProps = {

--- a/src/utils/parentScroll.js
+++ b/src/utils/parentScroll.js
@@ -6,7 +6,7 @@ const style = (element, prop) =>
 const overflow = (element) =>
   style(element, 'overflow') + style(element, 'overflow-y') + style(element, 'overflow-x');
 
-const hasClassName = (className) => (element) => element.classList.contains(className);
+const hasClassName = (element, className) => element.classList.contains(className);
 
 const hasValidOverflow = (element) => /(scroll|auto)/.test(overflow(element));
 
@@ -14,8 +14,6 @@ const scrollParent = (element, wrapperClassName) => {
   if (!(element instanceof HTMLElement)) {
     return window;
   }
-
-  const isWrapperElement = wrapperClassName ? hasClassName(wrapperClassName) : hasValidOverflow;
 
   let parent = element;
 
@@ -28,7 +26,7 @@ const scrollParent = (element, wrapperClassName) => {
       break;
     }
 
-    if (isWrapperElement(parent)) {
+    if (hasClassName(parent, wrapperClassName) || hasValidOverflow(parent)) {
       return parent;
     }
 

--- a/src/utils/parentScroll.js
+++ b/src/utils/parentScroll.js
@@ -6,10 +6,16 @@ const style = (element, prop) =>
 const overflow = (element) =>
   style(element, 'overflow') + style(element, 'overflow-y') + style(element, 'overflow-x');
 
-const scrollParent = (element) => {
+const hasClassName = (className) => (element) => element.classList.contains(className);
+
+const hasValidOverflow = (element) => /(scroll|auto)/.test(overflow(element));
+
+const scrollParent = (element, wrapperClassName) => {
   if (!(element instanceof HTMLElement)) {
     return window;
   }
+
+  const isWrapperElement = wrapperClassName ? hasClassName(wrapperClassName) : hasValidOverflow;
 
   let parent = element;
 
@@ -22,7 +28,7 @@ const scrollParent = (element) => {
       break;
     }
 
-    if (/(scroll|auto)/.test(overflow(parent))) {
+    if (isWrapperElement(parent)) {
       return parent;
     }
 


### PR DESCRIPTION
This allow users to specify a wrapper className for the lib to find the right parent instead of search for a valid overflow property