### PR TITLE
feature/component_should_update_on_height_change

### DIFF
--- a/src/LazyLoad.jsx
+++ b/src/LazyLoad.jsx
@@ -47,7 +47,7 @@ export default class LazyLoad extends Component {
   }
 
   shouldComponentUpdate(_nextProps, nextState) {
-    return nextState.visible;
+    return nextState.visible || _nextProps.height !== this.props.height;
   }
 
   componentWillUnmount() {


### PR DESCRIPTION
- component should update on height change

Hi,
We have a case where we have two views on-page, single and double columns, and the component didn't update on height change.
Probably it is related somehow to our new CRA build (SSR + SPA), and client hydration.
After this one-liner fix, everything works flawlessly. 